### PR TITLE
Fix TypeScript strictness issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -761,7 +761,7 @@ class CaplDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
             const variableMatch = line.match(variablePattern);
             if (variableMatch) {
                 const variableType = variableMatch[1];
-                const variableNames = variableMatch[2].split(',').map(name => name.trim());
+                const variableNames = variableMatch[2].split(',').map((name: string) => name.trim());
                 
                 for (const variableName of variableNames) {
                     const variableSymbol = new vscode.DocumentSymbol(


### PR DESCRIPTION
## Summary
- add missing type annotation for variable names

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode')*