### PR TITLE
Fix LanguageClient initialization

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,8 @@ export function activate(context: ExtensionContext) {
     };
 
     client = new LanguageClient('capl-lsp', 'CAPL Language Server', serverOptions, clientOptions);
-    context.subscriptions.push(client.start());
+    context.subscriptions.push(client);
+    client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
## Summary
- push the LanguageClient itself to `context.subscriptions`
- start the client separately to avoid type error

## Testing
- `tsc -p ./` *(fails: Cannot find module 'path' or its corresponding type declarations)*